### PR TITLE
force continuous aggregates type to MaterializedView

### DIFF
--- a/dbt/include/timescaledb/macros/materializations/models/continuous_aggregate.sql
+++ b/dbt/include/timescaledb/macros/materializations/models/continuous_aggregate.sql
@@ -1,6 +1,9 @@
 {%- materialization continuous_aggregate, adapter="timescaledb" -%}
 
   {%- set existing_relation = load_cached_relation(this) -%}
+  {% if existing_relation is not none %}
+      {%- set existing_relation = existing_relation.incorporate(type=this.MaterializedView) -%}
+  {% endif %}
   {%- set target_relation = this.incorporate(type=this.MaterializedView) -%}
   {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
 
@@ -8,6 +11,9 @@
   -- will return None in that case. Otherwise, we get a relation that we can drop
   -- later, before we try to use this name for the current operation
   {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+  {% if preexisting_intermediate_relation is not none %}
+    {%- set preexisting_intermediate_relation = preexisting_intermediate_relation.incorporate(type=this.MaterializedView) -%}
+  {% endif %}
   /*
      This relation (probably) doesn't exist yet. If it does exist, it's a leftover from
      a previous run, and we're going to try to drop it immediately. At the end of this
@@ -25,6 +31,9 @@
   {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
   -- as above, the backup_relation should not already exist
   {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+  {% if preexisting_backup_relation is not none %}
+    {%- set preexisting_backup_relation = preexisting_backup_relation.incorporate(type=this.MaterializedView) -%}
+  {% endif %}
   -- grab current tables grants config for comparision later on
   {% set grant_config = config.get('grants') %}
 
@@ -58,6 +67,7 @@
         since the variable was first set. */
     {% set existing_relation = load_cached_relation(existing_relation) %}
     {% if existing_relation is not none %}
+      {%- set existing_relation = existing_relation.incorporate(type=this.MaterializedView) -%}
         {{ adapter.rename_relation(existing_relation, backup_relation) }}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
Hi! Thank you for the plugin!
Consider this PR as more of an issue, as I'm unsure of the ultimate solution here - I just wanted to share what worked for us.

We faced an issue when running `dbt run --full-refresh --select agg__daily_sent_email `:
```
1 of 1 ERROR creating sql continuous_aggregate model public.agg__daily_sent_email  [[31mERROR[0m in 0.25s]
  Database Error in model agg__daily_sent_email (models/aggregates/agg__daily_sent_email.sql)
  cannot alter continuous aggregate using ALTER VIEW
  HINT:  Use ALTER MATERIALIZED VIEW to alter a continuous aggregate.
```
I tracked it down to the query `dbt` runs to populate its relation cache:
```
select
  'reporting_dev' as database,
  tablename as name,
  schemaname as schema,
  'table' as type
from pg_tables
where schemaname ilike 'public'
union all
select
  'reporting_dev' as database,
  viewname as name,
  schemaname as schema,
  'view' as type
from pg_views
where schemaname ilike 'public'
union all
select
  'reporting_dev' as database,
  matviewname as name,
  schemaname as schema,
  'materialized_view' as type
from pg_matviews
where schemaname ilike 'public';
```
which for some reason classifies our continuous aggregates as just `view` and not `materialized_view`, which breaks the rename and drop macros.

Our solution was to force the type to be `MaterializedView` so those macros would do the right thing. This is working for us right now, but it's probably a hack. I have no idea why timescaledb says continuous aggregates are views.

This doesn't pop-up when running a complete full refresh with `dbt run --full-resfresh` because, I assume, `dbt` thinks the relations don't exist anymore, so the `preexisting_*` variables are set to `None`.

Thanks!